### PR TITLE
Handle single quote

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,6 +116,15 @@ mod tests {
     }
 
     #[test]
+    fn different_quote_types_nested() {
+        let command = Command::from_str("ls 'a \"b\" c'").expect("parse nested quotes");
+        assert_eq!(command.arguments, &["a \"b\" c"]);
+
+        let command = Command::from_str("ls \"a 'b' c\"").expect("parse nested quotes");
+        assert_eq!(command.arguments, &["a 'b' c"]);
+    }
+
+    #[test]
     #[should_panic]
     fn empty_fails() {
         Command::from_str("    ").unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ err_type!(pub, EmptyCommandError, "command string has no command name or argumen
 
 /// Contains the result of a parsed command. See [`Command::from_str`] documentation for details on
 /// available command syntax.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct Command {
     /// The name of the command being run (i.e. the first argument)
     pub name: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,6 +106,16 @@ mod tests {
     }
 
     #[test]
+    fn quoted_arguments() {
+        let double_quoted =
+            Command::from_str("ls \"dir with spaces\"").expect("parse single quoted");
+        let single_quoted = Command::from_str("ls 'dir with spaces'").expect("parse double quoted");
+        assert_eq!(double_quoted, single_quoted, "Double and single quoted arguments not treated equally");
+        assert_eq!(double_quoted.arguments, &["dir with spaces"]);
+        assert_eq!(single_quoted.arguments, &["dir with spaces"]);
+    }
+
+    #[test]
     #[should_panic]
     fn empty_fails() {
         Command::from_str("    ").unwrap();

--- a/src/syntax_blocks.rs
+++ b/src/syntax_blocks.rs
@@ -73,10 +73,11 @@ pub struct QuoteBlock;
 
 impl SyntaxBlock for QuoteBlock {
     fn consume(&self, input: &mut ParserData) -> bool {
-        if input.peek().unwrap() == '"' {
+        let quotation_char = input.peek().unwrap();
+        if quotation_char == '"' || quotation_char == '\'' {
             input.eat().unwrap();
 
-            while input.not_empty() && input.peek().unwrap() != '"' {
+            while input.not_empty() && input.peek().unwrap() != quotation_char {
                 handle_or_push(input, &vec![ &EscapeBlock{} ]);
             }
 


### PR DESCRIPTION
Hi. Handy library here! However I noticed it treats single and double quotes differently. I'm not sure exactly which shell is intended by "parses shell-style commands" in the crate description. In bash both `ls 'dir with spaces'` and `ls "dir with spaces"` works equally well, but this library currently parses them very differently.

This PR adds tests and fixes the code to handle the above.